### PR TITLE
Fix/get plugins for lang

### DIFF
--- a/deeptracy_core/__init__.py
+++ b/deeptracy_core/__init__.py
@@ -3,4 +3,4 @@
 
 from .dal import *
 
-__version__ = '0.0.7'
+__version__ = '0.0.8'

--- a/deeptracy_core/dal/plugin/manager.py
+++ b/deeptracy_core/dal/plugin/manager.py
@@ -44,7 +44,7 @@ def get_plugins_for_lang(lang: str, session: Session):
     """
     query = session.query(Plugin)\
         .filter(Plugin.lang == lang)\
-        .filter(Plugin.active is True)
+        .filter(Plugin.active == True)
     return query.all()
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.7
+current_version = 0.0.8
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ test_requirements = [str(ir.req) for ir in parse_requirements(
 
 setup(
     name='deeptracy_core',
-    version='0.0.7',
+    version='0.0.8',
     author='BBVA',
     url="https://github.com/BBVA/deeptracy-core",
     description='Deeptracy Dependency Checker',


### PR DESCRIPTION
Fix get_plugins_for_lang not working as expected, sqlalchemy doesn't like comparisons in filters with "is" and must be changes to "=="